### PR TITLE
Add FME requirement via Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,4 +18,6 @@ License: CCO
 Encoding: UTF-8
 LazyData: true
 LazyLoad: true
+Imports:
+    FME (>1.3.6)
 RoxygenNote: 7.0.2


### PR DESCRIPTION
The FME package is required when installing LakeEnsemblR. Use the Imports section of the DESCRIPTION to do this.

The latest version of FME as of 2019-12-18 is 1.3.6.1 so require 1.3.6 just in case the 4th digit causes issues.

Addresses https://github.com/aemon-j/LakeEnsemblR/issues/55