### PR TITLE
Default value a_seiche in Simstrat

### DIFF
--- a/R/export_location.R
+++ b/R/export_location.R
@@ -174,6 +174,13 @@ export_location <- function(config_file, model = c("GOTM", "GLM", "Simstrat", "F
       input_json(sim_par, "ModelConfig", "SnowModel", 0)
     }
     
+    # Calculate default value a_seiche
+    # Based on a relation between surface area and calibrated a_seiche
+    # in the study of Gaudard et al. (2019). Data used to construct this
+    # relation is to be found on https://simstrat.eawag.ch/lakes
+    surf_area <- max(sim_hyp[, 2]) / 1000000 # in km2
+    a_seiche <- 10^(-2.8591 + 0.7029 * log10(surf_area))
+    input_json(sim_par, "ModelParameters", "a_seiche", a_seiche)
   }
   
   ##---------------MyLake-------------

--- a/inst/extdata/feeagh/LakeEnsemblR.yaml
+++ b/inst/extdata/feeagh/LakeEnsemblR.yaml
@@ -62,7 +62,6 @@ model_parameters:
    GOTM:                                       # GOTM specific parameters
       k_min: 3.6E-6                            # minimum turbulent kinetic energy [m^2/s^2; min=0.0; default=1.00000000E-10]
    Simstrat:                                   # Simstrat specific parameters
-      a_seiche: 0.001                          # Fraction of wind energy which goes into seiche energy [-]
    MyLake:                                     # MyLake specific parameters
       Phys.par/C_shelter: 0.15                 # wind sheltering coefficient [min=0; max=1; default=NULL to calculate C_shelter=1.0-exp(-0.3*SA)]
 calibration:                                   # Calibration section                                   # Calibration section


### PR DESCRIPTION
The default value of a_seiche is calculated in export_location, based on a relation with surface area using data from simstrat.eawag.ch