### PR TITLE
Add N rows in hyps file to GLM max_layers to avoid crashes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ### Changes
 
 - fixed a bug in the LHC calibration where if a model would crash on the first run the headding of the ouput file would be wrong
+- Add the number of rows in the hypsograph file to the calculated `max_layers` parameter in GLM, to avoid failure of Lagrangian algorithm
 
 ## version 1.1.8
 

--- a/R/export_location.R
+++ b/R/export_location.R
@@ -112,9 +112,9 @@ export_location <- function(config_file, model = c("GOTM", "GLM", "Simstrat", "F
     bsn_len <- 2 * bsn_wid
     # Can be overwritten by providing values in the model_parameters section of config_file
 
-    # Calculate max number of layers
+    # Calculate max number of layers - to avoid failure of Lagrangian algorithm
     min_layer_thick <- get_nml_value(nml, "min_layer_thick")
-    max_layers <- round(max_depth / min_layer_thick)
+    max_layers <- round(max_depth / min_layer_thick) + nrow(hyp)
     
     # 2022-02-03: template file in GLM3r, ggplot-overhaul branch does not have crest_elev
     if(!("crest_elev" %in% names(nml[["morphometry"]]))){


### PR DESCRIPTION
GLM could previously crash due to the number of layers exceeding the `max_layers` parameter value. This change should avoid this error from occurring, except in extreme cases. 

Note that if `min_layer_thick` is calibrated, the `max_layers` parameter will not automatically adjust