### PR TITLE
fixed bug in export_model_parameters regarding folder argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: LakeEnsemblR
 Type: Package
 Title: Run Ensemble of Lake Models
-Version: 1.2.7
+Version: 1.2.8
 Date: 2024-04-25
 URL: https://github.com/aemon-j/LakeEnsemblR
 Author: Authors@R: c(person("Tadhg", "Moore", role = c("aut","cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ### Changes
 - bug fix of `export_model_parameters` function when using `folder` argument other than `"."`
+- bug fix in `cali_ensemble` when unit of observations is seconds
 
 ## version 1.2.7
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## version 1.2.8
+
+### Changes
+- bug fix of `export_model_parameters` function when using `folder` argument other than `"."`
+
 ## version 1.2.7
 
 ### Changes

--- a/R/cali_ensemble.R
+++ b/R/cali_ensemble.R
@@ -167,6 +167,10 @@ cali_ensemble <- function(config_file, num = NULL, param_file = NULL, cmethod = 
   stop <- gotmtools::get_yaml_value(yaml, label = "location", key = "stop")
   obs_file <- gotmtools::get_yaml_value(file = yaml, label = "temperature", key = "file")
   time_unit <- gotmtools::get_yaml_value(yaml, "output", "time_unit")
+  if(time_unit == "second"){
+    # Needed to create out_time vector
+    time_unit <- "sec"
+  }
   time_step <- gotmtools::get_yaml_value(yaml, "output", "time_step")
   cnfg_l <- lapply(model, function(m) gotmtools::get_yaml_value(yaml, "config_files", m))
   names(cnfg_l) <- model

--- a/R/export_model_parameters.R
+++ b/R/export_model_parameters.R
@@ -50,7 +50,8 @@ export_model_parameters <- function(config_file,
       }
       
       tryCatch({input_config_value(model = i,
-                                   file = model_config,
+                                   file = basename(model_config),
+                                   folder = dirname(model_config),
                                    label = label,
                                    key = key,
                                    value = master_config[["model_parameters"]][[i]][[j]])


### PR DESCRIPTION
I found and fixed a bug where if the `folder` argument in `export_model_parameters()` is not `"."` the model specific settings will not be exported.